### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ conda install sstmap
 You can install the latest development version from the GitHub repository by executing
 
 ```
-pip install git+git://github.com/kurtzmanlab/sstmap.git#egg=sstmap
+pip install git+git://github.com/kurtzmanlab/sstmap.git@v1.0#egg=sstmap
 ```
 
 You can also download the package manually from GitHub, unzip it, navigate into the directory, and execute the command:
@@ -42,6 +42,7 @@ You can also download the package manually from GitHub, unzip it, navigate into 
 ```bash
 git clone git@github.com:KurtzmanLab/SSTMap.git
 cd SSTMap
+git checkout tags/v1.0
 python setup.py install
 ```
 Usage


### PR DESCRIPTION
Fixed command line to checkout v1.0 when installing from source, using pip or manually.

Now the source is the correct one.